### PR TITLE
Add 1 more test script test:all

### DIFF
--- a/person-list/README.md
+++ b/person-list/README.md
@@ -35,14 +35,13 @@ See the section about [running tests](https://facebook.github.io/create-react-ap
 
 In thie project, we provide 2 test scripts for differenct usage, please check below:
 ```
-"test": "react-scripts test",
+"test": "react-scripts test --coverage",
 "test:all": "react-scripts test --coverage --watchAll=false",
 ```
 **Test Script Usage:**
 
-1. If you wanna do **test only**, just use `npm test`
-2. If you wanna do test with **run coverage report only with files changed since last commit**, use `npm test -- --coverage`
-3. If you wanna do test with **run coverage report with all test files (changed or not)**, use `npm run test:all`
+1. If you wanna execute testing with **run coverage report only with files changed since last commit**, use `npm test`
+2. If you wanna execute testing with **run coverage report with all test files (changed or not)**, use `npm run test:all`
 
 ### `npm run build`
 

--- a/person-list/package-lock.json
+++ b/person-list/package-lock.json
@@ -7890,13 +7890,11 @@
             },
             "minimist": {
               "version": "1.2.5",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -7913,7 +7911,6 @@
             "mkdirp": {
               "version": "0.5.3",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "^1.2.5"
               }
@@ -7969,8 +7966,7 @@
             },
             "npm-normalize-package-bin": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "npm-packlist": {
               "version": "1.4.8",
@@ -8075,8 +8071,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -8168,8 +8163,7 @@
             },
             "yallist": {
               "version": "3.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         }
@@ -14008,8 +14002,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -14046,8 +14039,7 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
@@ -14056,8 +14048,7 @@
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -14160,8 +14151,7 @@
             },
             "inherits": {
               "version": "2.0.4",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -14171,7 +14161,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -14197,7 +14186,6 @@
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -14214,7 +14202,6 @@
             "mkdirp": {
               "version": "0.5.3",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "^1.2.5"
               }
@@ -14270,8 +14257,7 @@
             },
             "npm-normalize-package-bin": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "npm-packlist": {
               "version": "1.4.8",
@@ -14296,8 +14282,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -14307,7 +14292,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -14376,8 +14360,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -14407,7 +14390,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -14425,7 +14407,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -14464,13 +14445,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },

--- a/person-list/package.json
+++ b/person-list/package.json
@@ -37,6 +37,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
+    "test:all": "react-scripts test --coverage --watchAll=false",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/person-list/package.json
+++ b/person-list/package.json
@@ -36,7 +36,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
+    "test": "react-scripts test --coverage",
     "test:all": "react-scripts test --coverage --watchAll=false",
     "eject": "react-scripts eject"
   },

--- a/person-list/src/App.tsx
+++ b/person-list/src/App.tsx
@@ -48,7 +48,7 @@ const App: FC = () => {
     <div className="App">
       <Auth />
       <span>Person List</span>
-      <Stack data-testid="person-list-stack">
+      <Stack>
         <UserList users={appState.users} />
       </Stack>
     </div>


### PR DESCRIPTION
**Why:** we will need to add test code coverage inspection in the project, so we separate original test only and test with code coverage in different scripts.

**Note:** Flag `--watchAll:false` means code coverage will run all the testing files again

Usage: 
1. If you wanna do **test only**, just run `npm test`
2. If you wanna do test with **run coverage report only with files changed since last commit**, run `npm test -- --coverage`
3. If you wanna do test with **run coverage report with all test files (changed or not)**, run `npm run test:all`
